### PR TITLE
Update UserEntity to support all OIDCC defined claims

### DIFF
--- a/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
@@ -20,6 +20,10 @@ package com.authlete.jaxrs.server.db;
 import com.authlete.common.dto.Address;
 import com.authlete.common.types.User;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+
 
 /**
  * Operations to access the user database.
@@ -32,8 +36,12 @@ public class UserDao
      * Dummy user database.
      */
     private static final UserEntity[] sUserDB = {
-            new UserEntity("1001", "john", "john", "John Smith", "john@example.com",
-                    new Address().setCountry("USA"), "+1 (425) 555-1212", "675325"),
+            new UserEntity("1001", "john", "john", "John Flibble Smith", "john@example.com",
+                    new Address().setCountry("USA Flibble"), "+1 (425) 555-1212", "675325",
+                    "John", "Smith", "Doe", "Johnny",
+                    "https://example.com/john/profile", "https://example.com/john/me.jpg",
+                    "https://example.com/john/", "male", "Europe/London",
+                    "en-US", "john", "0000-03-22", Date.from(LocalDate.parse("2020-01-01").atStartOfDay().toInstant(ZoneOffset.UTC))),
             new UserEntity("1002", "jane", "jane", "Jane Smith", "jane@example.com",
                     new Address().setCountry("Chile"), "+56 (2) 687 2400", "264209"),
             new UserEntity("1003", "max", "max", "Max Meier", "max@example.com",

--- a/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
@@ -21,6 +21,8 @@ import com.authlete.common.dto.Address;
 import com.authlete.common.types.StandardClaims;
 import com.authlete.common.types.User;
 
+import java.util.Date;
+
 
 /**
  * Dummy user entity that represents a user record.
@@ -76,6 +78,22 @@ public class UserEntity implements User
      */
     private String code;
 
+    // Below are standard claims as defined in https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+    private boolean phoneNumberVerified;
+    private boolean emailVerified;
+    private String givenName;
+    private String familyName;
+    private String middleName;
+    private String nickName;
+    private String profile;
+    private String picture;
+    private String website;
+    private String gender;
+    private String zoneinfo;
+    private String locale;
+    private String preferredUsername;
+    private String birthdate;
+    private Date updatedAt;
 
     /**
      * Constructor with initial values.
@@ -92,6 +110,37 @@ public class UserEntity implements User
         this.address     = address;
         this.phoneNumber = phoneNumber;
         this.code        = code;
+    }
+
+    public UserEntity(
+            String subject, String loginId, String password, String name,
+            String email, Address address, String phoneNumber, String code,
+            String givenName, String familyName, String middleName,
+            String nickName, String profile, String picture, String website,
+            String gender, String zoneinfo, String locale,
+            String preferredUsername, String birthdate, Date updatedAt)
+    {
+        this.subject     = subject;
+        this.loginId     = loginId;
+        this.password    = password;
+        this.name        = name;
+        this.email       = email;
+        this.address     = address;
+        this.phoneNumber = phoneNumber;
+        this.code        = code;
+        this.givenName   = givenName;
+        this.familyName  = familyName;
+        this.middleName  = middleName;
+        this.nickName    = nickName;
+        this.profile     = profile;
+        this.picture     = picture;
+        this.website     = website;
+        this.gender      = gender;
+        this.zoneinfo    = zoneinfo;
+        this.locale      = locale;
+        this.preferredUsername = preferredUsername;
+        this.birthdate   = birthdate;
+        this.updatedAt   = updatedAt;
     }
 
 
@@ -156,6 +205,51 @@ public class UserEntity implements User
                 // "phone_number" claim. This claim can be requested by including "phone"
                 // in "scope" parameter of an authorization request.
                 return phoneNumber;
+
+            case StandardClaims.PHONE_NUMBER_VERIFIED:
+                return phoneNumberVerified;
+
+            case StandardClaims.EMAIL_VERIFIED:
+                return emailVerified;
+
+            case StandardClaims.BIRTHDATE:
+                return birthdate;
+
+            case StandardClaims.GIVEN_NAME:
+                return givenName;
+
+            case StandardClaims.FAMILY_NAME:
+                return familyName;
+
+            case StandardClaims.MIDDLE_NAME:
+                return middleName;
+
+            case StandardClaims.NICKNAME:
+                return nickName;
+
+            case StandardClaims.PROFILE:
+                return profile;
+
+            case StandardClaims.PICTURE:
+                return picture;
+
+            case StandardClaims.WEBSITE:
+                return website;
+
+            case StandardClaims.GENDER:
+                return gender;
+
+            case StandardClaims.ZONEINFO:
+                return zoneinfo;
+
+            case StandardClaims.LOCALE:
+                return locale;
+
+            case StandardClaims.UPDATED_AT:
+                return updatedAt.getTime() / 1000l;
+
+            case StandardClaims.PREFERRED_USERNAME:
+                return preferredUsername;
 
             default:
                 // Unsupported claim.


### PR DESCRIPTION
The main reason for doing this is so that the new java conformance tests
for the userinfo endpoint pass without warnings for
response_type=id_token.

We add a new constructor that takes all the claims, and leave the
previous constructor in place for backwards compatibility.