### PR TITLE
Disable autocorrect/autocapitalisation for username field

### DIFF
--- a/src/main/webapp/WEB-INF/template/authorization.jsp
+++ b/src/main/webapp/WEB-INF/template/authorization.jsp
@@ -157,6 +157,7 @@ ${model.authorizationDetails}
         <div id="login-fields" class="indent">
           <div id="login-prompt">Input Login ID and password.</div>
           <input type="text" id="loginId" name="loginId" placeholder="Login ID"
+                 autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
                  class="font-default" required value="${model.loginId}" ${model.loginIdReadOnly}>
           <input type="password" id="password" name="password" placeholder="Password"
                  class="font-default" required>


### PR DESCRIPTION
Otherwise Safari on iOS defaults to uppercasing the first
character of the username