### PR TITLE
Userinfo: Remove support for access token in url query

### DIFF
--- a/src/main/java/com/authlete/jaxrs/server/api/UserInfoEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/UserInfoEndpoint.java
@@ -54,12 +54,11 @@ public class UserInfoEndpoint extends BaseUserInfoEndpoint
     public Response get(
             @HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @HeaderParam("DPoP") String dpop,
-            @QueryParam("access_token") String accessToken,
             @Context HttpServletRequest request)
     {
         // Select either the access token embedded in the Authorization header
         // or the access token in the query component.
-        accessToken = extractAccessToken(authorization, accessToken);
+        String accessToken = extractAccessToken(authorization, null);
 
         // Handle the userinfo request.
         return handle(request, accessToken, dpop);


### PR DESCRIPTION
FAPI says this must not be supported.