### PR TITLE
Update properties file comments for Authlete 3.0 configuration

### DIFF
--- a/authlete.properties
+++ b/authlete.properties
@@ -42,8 +42,16 @@ service.api_key = 5593494639
 service.api_secret = AAw0rner_-y1A6J9s20wjRCpkBvez3GxEBoL9jOJVR0
 
 # For Authlete 3.0
+# 
+# To use Authlete 3.0, you need to uncomment the block starting from the line "api_version = V3".
+# 
+# The base_url should be selected based on your service's cluster region (for the Shared Cloud version):
+#   https://us.authlete.com - 🇺🇸 US Cluster
+#   https://jp.authlete.com - 🇯🇵 Japan Cluster
+#   https://eu.authlete.com - 🇪🇺 Europe Cluster
+#   https://br.authlete.com - 🇧🇷 Brazil Cluster
 #
 #api_version = V3
-#base_url = https://nextdev-api.authlete.net
+#base_url = https://<region>.authlete.com
 #service.api_key = 986126671
 #service.access_token =


### PR DESCRIPTION
- Added instructions to uncomment the block starting with "api_version = V3" for Authlete 3.0 usage.
- Clarified that the base_url should be selected based on the service's cluster region (for Shared Cloud version).
- Updated the initial value of base_url to use the format "https://`<region>`.authlete.com".