### PR TITLE
Native SSO Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <authlete.java.common.version>4.12</authlete.java.common.version>
-    <authlete.java.jaxrs.version>2.80</authlete.java.jaxrs.version>
+    <authlete.java.common.version>4.19</authlete.java.common.version>
+    <authlete.java.jaxrs.version>2.86</authlete.java.jaxrs.version>
     <authlete.cbor.version>1.18</authlete.cbor.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <jersey.version>2.30.1</jersey.version>

--- a/src/main/java/com/authlete/jaxrs/server/api/AuthorizationDecisionEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/AuthorizationDecisionEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Authlete, Inc.
+ * Copyright (C) 2016-2025 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ package com.authlete.jaxrs.server.api;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.Consumes;
@@ -110,7 +109,8 @@ public class AuthorizationDecisionEndpoint extends BaseAuthorizationDecisionEndp
         // Implementation of AuthorizationDecisionHandlerSpi.
         AuthorizationDecisionHandlerSpi spi =
             new AuthorizationDecisionHandlerSpiImpl(
-                parameters, user, authTime, idTokenClaims, acrs, client);
+                parameters, user, authTime, idTokenClaims, acrs, client,
+                session.getId());
 
         // Handle the end-user's decision.
         return handle(AuthleteApiFactory.getDefaultApi(), spi, params);

--- a/src/main/java/com/authlete/jaxrs/server/api/AuthorizationDecisionHandlerSpiImpl.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/AuthorizationDecisionHandlerSpiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Authlete, Inc.
+ * Copyright (C) 2016-2025 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,12 @@ class AuthorizationDecisionHandlerSpiImpl extends AuthorizationDecisionHandlerSp
 
 
     /**
+     * The session ID of the user's authentication session.
+     */
+    private String mSessionId;
+
+
+    /**
      * Constructor with a request from the form in the authorization page.
      *
      * <p>
@@ -114,7 +120,8 @@ class AuthorizationDecisionHandlerSpiImpl extends AuthorizationDecisionHandlerSp
      */
     public AuthorizationDecisionHandlerSpiImpl(
             MultivaluedMap<String, String> parameters, User user,
-            Date userAuthenticatedAt, String idTokenClaims, String[] acrs, Client client)
+            Date userAuthenticatedAt, String idTokenClaims, String[] acrs,
+            Client client, String sessionId)
     {
         // If the end-user clicked the "Authorize" button, "authorized"
         // is contained in the request.
@@ -159,6 +166,9 @@ class AuthorizationDecisionHandlerSpiImpl extends AuthorizationDecisionHandlerSp
 
         // The client associated with the request.
         mClient = client;
+
+        // The session ID of the user's authentication session.
+        mSessionId = sessionId;
     }
 
 
@@ -255,7 +265,7 @@ class AuthorizationDecisionHandlerSpiImpl extends AuthorizationDecisionHandlerSp
 
         try
         {
-            return (Map<String, Object>)Utils.fromJson(json, Map.class);
+            return Utils.fromJson(json, Map.class);
         }
         catch (Exception e)
         {
@@ -482,5 +492,12 @@ class AuthorizationDecisionHandlerSpiImpl extends AuthorizationDecisionHandlerSp
         // Build the content of "verified_claims" which meets conditions
         // of the request from the available datasets.
         return new VerifiedClaimsBuilder(verifiedClaimsRequest, datasets).build();
+    }
+
+
+    @Override
+    public String getSessionId()
+    {
+        return mSessionId;
     }
 }

--- a/src/main/java/com/authlete/jaxrs/server/api/JwtAuthzGrantProcessor.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/JwtAuthzGrantProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Authlete, Inc.
+ * Copyright (C) 2022-2025 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 package com.authlete.jaxrs.server.api;
 
 
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import com.authlete.common.api.AuthleteApi;
 import com.authlete.common.dto.TokenCreateRequest;
@@ -66,13 +69,19 @@ import com.nimbusds.jwt.SignedJWT;
 class JwtAuthzGrantProcessor
 {
     private final AuthleteApi mAuthleteApi;
+    private final HttpServletRequest mRequest;
     private final TokenResponse mTokenResponse;
+    private final Map<String, Object> mHeaders;
 
 
-    public JwtAuthzGrantProcessor(AuthleteApi authleteApi, TokenResponse tokenResponse)
+    public JwtAuthzGrantProcessor(
+            AuthleteApi authleteApi, HttpServletRequest request,
+            TokenResponse tokenResponse, Map<String, Object> headers)
     {
         mAuthleteApi   = authleteApi;
+        mRequest       = request;
         mTokenResponse = tokenResponse;
+        mHeaders       = headers;
     }
 
 
@@ -326,12 +335,29 @@ class JwtAuthzGrantProcessor
         cacheControl.setNoCache(true);
         cacheControl.setNoStore(true);
 
-        return Response
-                .status(status)
+        ResponseBuilder builder = Response.status(status)
                 .type(MediaType.APPLICATION_JSON_TYPE)
                 .cacheControl(cacheControl)
                 .entity(content)
-                .build();
+                ;
+
+        addResponseHeaders(builder, mHeaders);
+
+        return builder.build();
+    }
+
+
+    private static void addResponseHeaders(ResponseBuilder builder, Map<String, Object> headers)
+    {
+        if (headers == null)
+        {
+            return;
+        }
+
+        for (Map.Entry<String, Object> header : headers.entrySet())
+        {
+            builder.header(header.getKey(), header.getValue());
+        }
     }
 
 

--- a/src/main/java/com/authlete/jaxrs/server/api/NativeSsoProcessor.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/NativeSsoProcessor.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright (C) 2025 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package com.authlete.jaxrs.server.api;
+
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.dto.NativeSsoRequest;
+import com.authlete.common.dto.NativeSsoResponse;
+import com.authlete.common.dto.TokenResponse;
+import com.authlete.common.types.GrantType;
+import com.authlete.jaxrs.server.core.SessionTracker;
+import com.authlete.jaxrs.server.nativesso.DeviceSecret;
+import com.authlete.jaxrs.server.nativesso.DeviceSecretManager;
+import com.authlete.jaxrs.server.util.ResponseUtil;
+
+
+public class NativeSsoProcessor
+{
+    private final AuthleteApi mAuthleteApi;
+    private final HttpServletRequest mRequest;
+    private final TokenResponse mTokenResponse;
+    private final Map<String, Object> mHeaders;
+
+
+    public NativeSsoProcessor(
+            AuthleteApi authleteApi, HttpServletRequest request,
+            TokenResponse tokenResponse, Map<String, Object> headers)
+    {
+        mAuthleteApi   = authleteApi;
+        mRequest       = request;
+        mTokenResponse = tokenResponse;
+        mHeaders       = headers;
+    }
+
+
+    public Response process()
+    {
+        try
+        {
+            return createResponse();
+        }
+        catch (WebApplicationException cause)
+        {
+            return cause.getResponse();
+        }
+    }
+
+
+    private Response createResponse() throws WebApplicationException
+    {
+        // The device secret value and device secret hash that may be
+        // included in the response from the /auth/token API.
+        String deviceSecretValue = retrieveDeviceSecretValue();
+        String deviceSecretHash  = retrieveDeviceSecretHash();
+
+        // The session ID included in the response from the /auth/token API.
+        String sessionId = retrieveSessionId();
+
+        // The identifier of the device accessing this authorization server.
+        String deviceId = retrieveDeviceId();
+
+        // Validate the Native SSO parameters.
+        DeviceSecret ds = validateParameters(
+                deviceSecretValue, deviceSecretHash, sessionId, deviceId);
+
+        // Call Authlete's /nativesso API to generate a Native SSO-compliant
+        // ID token and a token response.
+        NativeSsoResponse nsr = nativeSso(ds);
+
+        // Generate a token response.
+        return generateResponse(nsr);
+    }
+
+
+    private String retrieveDeviceSecretValue()
+    {
+        // The device secret that may be included in the response from the
+        // /auth/token API.
+        //
+        // When the flow is the authorization code flow or the refresh token
+        // flow, the device secret is the value of the "device_secret" request
+        // parameter to the token endpoint.
+        //
+        // When the flow is the token exchange flow, the device secret is the
+        // value of the "actor_token" request parameter to the token endpoint.
+        return mTokenResponse.getDeviceSecret();
+    }
+
+
+    private String retrieveDeviceSecretHash()
+    {
+        // The device secret hash that may be included in the response from
+        // the /auth/token API.
+        //
+        // The device secret hash is available only when the flow is the token
+        // exchange flow. Its value originates from the "ds_hash" claim in the
+        // subject token.
+        return mTokenResponse.getDeviceSecretHash();
+    }
+
+
+    private String retrieveSessionId()
+    {
+        // The session ID included in the response from the /auth/token API.
+        //
+        // When the flow is the authorization code flow, the session ID is the
+        // value included in the preceding call of the /auth/authorization/issue
+        // API.
+        //
+        // When the flow is the refresh token flow, the session ID is the one
+        // associated with the refresh token.
+        //
+        // When the flow is the token exchange flow, the session ID is the
+        // value of the "sid" claim in the subject token.
+        return mTokenResponse.getSessionId();
+    }
+
+
+    private String retrieveDeviceId()
+    {
+        // Information that can identify the device should be extracted from the
+        // HTTP request (mRequest) and processed before being used as a device ID.
+        //
+        // However, this sample implementation does not perform such processing.
+        // As a result, it cannot determine whether Native App 1 and Native App 2
+        // are running on the same device.
+        return null;
+    }
+
+
+    private DeviceSecret validateParameters(
+            String deviceSecretValue, String deviceSecretHash,
+            String sessionId, String deviceId)
+    {
+        // Validate the session ID.
+        validateSessionId(sessionId);
+
+        if (deviceSecretValue == null)
+        {
+            // This happens when (1) the flow is either the authorization code
+            // flow or the refresh token flow, and (2) the token request does
+            // not contain the "device_secret" request parameter.
+
+            // Create a new DeviceSecret instance and register it.
+            return createAndRegisterDeviceSecret(sessionId, deviceId);
+        }
+
+        // Look up the DeviceSecret instance corresponding to the device
+        // secret value specified by the "device_secret" request parameter
+        // or the "actor_token" request parameter.
+        DeviceSecret ds = DeviceSecretManager.getByValue(deviceSecretValue);
+
+        // If the specified device secret exists and is valid.
+        if (ds != null && isValid(ds, deviceSecretHash, sessionId, deviceId))
+        {
+            // Use the existing DeviceSecret instance.
+            return ds;
+        }
+
+        // The specified device secret does not exist or is invalid.
+
+        if (deviceSecretHash == null)
+        {
+            // This happens when (1) the flow is either the authorization code
+            // flow or the refresh token flow, and (2) the token request contains
+            // the "device_secret" request parameter.
+
+            // Since the Native SSO specification states as follows:
+            //
+            //   If a device_secret is provided as part of the token request,
+            //   and the device_secret is invalid, then the AS must process
+            //   the request as if no device_secret was specified.
+            //
+            // We don't treat this case as an error. Instead, we provide a
+            // new DeviceSecret instance.
+            return createAndRegisterDeviceSecret(sessionId, deviceId);
+        }
+
+        // This happens when (1) the flow is the token exchange flow.
+
+        // Build a message describing the error.
+        String message = buildInvalidDeviceSecretErrorMessage(
+                ds, deviceSecretValue, deviceSecretHash, sessionId, deviceId);
+
+        // 400 Bad Request with error=invalid_grant
+        throw invalidGrant(message);
+    }
+
+
+    private void validateSessionId(String sessionId)
+    {
+        // If the session ID is still active.
+        if (SessionTracker.isActiveSessionId(sessionId))
+        {
+            // Okay. The session is still active.
+            return;
+        }
+
+        // Build an error message indicating that the session ID is no longer valid.
+        String message = buildInvalidSessionIdErrorMessage(mTokenResponse.getGrantType());
+
+        // 400 Bad Request with error=invalid_grant
+        throw invalidGrant(message);
+    }
+
+
+    private static String buildInvalidSessionIdErrorMessage(GrantType grantType)
+    {
+        switch (grantType)
+        {
+            case AUTHORIZATION_CODE:
+                return "The session ID used during the authorization request is no longer valid.";
+
+            case REFRESH_TOKEN:
+                return "The session ID associated with the refresh token is no longer valid.";
+
+            case TOKEN_EXCHANGE:
+                return "The session ID associated with the subject token is no longer valid";
+
+            default:
+                // This should never happen.
+                return "The session ID associated with the token request is no longer valid.";
+        }
+    }
+
+
+    private DeviceSecret createAndRegisterDeviceSecret(String sessionId, String deviceId)
+    {
+        // Create a new DeviceSecret instance.
+        DeviceSecret ds = createDeviceSecret(sessionId, deviceId);
+
+        // Register it.
+        DeviceSecretManager.register(ds);
+
+        return ds;
+    }
+
+
+    private DeviceSecret createDeviceSecret(String sessionId, String deviceId)
+    {
+        // The device secret value.
+        String dsValue = generateDeviceSecretValue();
+
+        // The device secret hash.
+        String dsHash = computeDeviceSecretHash(dsValue);
+
+        // Create a DeviceSecret instance tied to the device and session.
+        return new DeviceSecret()
+                .setValue(dsValue)
+                .setHash(dsHash)
+                .setSessionId(sessionId)
+                .setDeviceId(deviceId)
+                ;
+    }
+
+
+    private String generateDeviceSecretValue()
+    {
+        // A random value.
+        return UUID.randomUUID().toString();
+    }
+
+
+    private String computeDeviceSecretHash(String deviceSecretValue)
+    {
+        // Compute the hash of the specified device secret value.
+        return DeviceSecret.computeHash(deviceSecretValue);
+    }
+
+
+    private boolean isValid(
+            DeviceSecret ds, String deviceSecretHash, String sessionId, String deviceId)
+    {
+        // If the device secret hash is specified.
+        if (deviceSecretHash != null)
+        {
+            // If the device secret hashes do not match.
+            if (!Objects.equals(ds.getHash(), deviceSecretHash))
+            {
+                // Invalid.
+                return false;
+            }
+        }
+
+        // If the session IDs do not match.
+        if (!Objects.equals(ds.getSessionId(), sessionId))
+        {
+            // Invalid.
+            return false;
+        }
+
+        // If the existing DeviceSecret instance is tied to a device ID.
+        if (ds.getDeviceId() != null)
+        {
+            // If the device IDs do not match.
+            if (!Objects.equals(ds.getDeviceId(), deviceId))
+            {
+                // Invalid.
+                return false;
+            }
+        }
+
+        // Valid.
+        return true;
+    }
+
+
+    private static String buildInvalidDeviceSecretErrorMessage(
+            DeviceSecret ds, String deviceSecretValue, String deviceSecretHash,
+            String sessionId, String deviceId)
+    {
+        // This method is called only from the context of the token exchange flow.
+
+        if (ds == null)
+        {
+            return String.format(
+                    "The specified device secret ('%s') does not exist.",
+                    deviceSecretValue);
+        }
+
+        // If the device secret hashes don't match.
+        if (!Objects.equals(ds.getHash(), deviceSecretHash))
+        {
+            return String.format(
+                    "The device secret hash ('%s') in the subject token does " +
+                    "not match the hash of the presented device secret ('%s').",
+                    deviceSecretHash, deviceSecretValue);
+        }
+
+        // If the session IDs don't match.
+        if (!Objects.equals(ds.getSessionId(), sessionId))
+        {
+            return String.format(
+                    "The session ID ('%s') in the subject token does not match " +
+                    "the one associated with the presented device secret ('%s').",
+                    sessionId, deviceSecretValue);
+        }
+
+        // If the existing device secret is tied to a device ID and it does not
+        // match the identifier of the device accessing this authorization server.
+        if (ds.getDeviceId() != null && !Objects.equals(ds.getDeviceId(), deviceId))
+        {
+            return String.format(
+                    "The identifier of the device accessing this authorization " +
+                    "server does not match the one associated with the presented " +
+                    "device secret ('%s').",
+                    deviceSecretValue);
+        }
+
+        // Hmm. The code flow should not reach here.
+        return String.format(
+                "The specified device secret ('%s') is invalid for an unknown reason.",
+                deviceSecretValue);
+    }
+
+
+    private NativeSsoResponse nativeSso(DeviceSecret ds)
+    {
+        // Prepare request parameters for the /nativesso API.
+        NativeSsoRequest request = new NativeSsoRequest()
+                .setAccessToken(chooseAccessToken())
+                .setRefreshToken(mTokenResponse.getRefreshToken())
+                .setDeviceSecret(ds.getValue())
+                .setDeviceSecretHash(ds.getHash())
+                ;
+
+        try
+        {
+            // Call Authlete's /nativesso API.
+            return mAuthleteApi.nativeSso(request, null);
+        }
+        catch (Exception cause)
+        {
+            // API call to /nativeSso failed.
+            cause.printStackTrace();
+
+            throw serverError("API call to /nativesso failed: " + cause.getMessage());
+        }
+    }
+
+
+    private String chooseAccessToken()
+    {
+        // The access token in the JWT format. Whether this is available
+        // depends on configuration.
+        String jwtAt = mTokenResponse.getJwtAccessToken();
+
+        return (jwtAt != null) ? jwtAt : mTokenResponse.getAccessToken();
+    }
+
+
+    private Response generateResponse(NativeSsoResponse nsr)
+    {
+        // The message body of the token response the /nativesso API prepared.
+        String content = nsr.getResponseContent();
+
+        // Dispatch according to the "action" parameter in the response from
+        // the /nativesso API.
+        switch (nsr.getAction())
+        {
+            case OK:
+                // 200 OK with application/json
+                return ResponseUtil.okJson(content, mHeaders);
+
+            case INTERNAL_SERVER_ERROR:
+            case CALLER_ERROR:
+                // 500 Internal Server Error with application/json
+                return ResponseUtil.internalServerErrorJson(content, mHeaders);
+
+            default:
+                // 500 Internal Server Error with application/json
+                throw unknownAction(nsr.getAction());
+        }
+    }
+
+
+    private WebApplicationException invalidGrant(String message)
+    {
+        // {"error":"invalid_grant", "error_description":"<message>"}
+        String content = buildErrorJson("invalid_grant", message);
+
+        // 400 Bad Request with application/json
+        Response response = ResponseUtil.badRequestJson(content, mHeaders);
+
+        // Wrap the response in a WebApplicationException.
+        return new WebApplicationException(response);
+    }
+
+
+    private WebApplicationException serverError(String message)
+    {
+        // {"error":"server_error", "error_description":"<message>"}
+        String content = buildErrorJson("server_error", message);
+
+        // 500 Internal Server Error with application/json
+        Response response = ResponseUtil.internalServerErrorJson(content, mHeaders);
+
+        // Wrap the response in a WebApplicationException.
+        return new WebApplicationException(response);
+    }
+
+
+    private WebApplicationException unknownAction(NativeSsoResponse.Action action)
+    {
+        String message = String.format(
+                "The /nativesso has returned an unknown action '%s'.", action);
+
+        // 500 Internal Server Error with application/json
+        return serverError(message);
+    }
+
+
+    private static String buildErrorJson(String error, String description)
+    {
+        return String.format(
+                "{\n" +
+                "  \"error\": \"%s\",\n" +
+                "  \"error_description\": \"%s\"\n" +
+                "}\n",
+                error, description);
+    }
+}

--- a/src/main/java/com/authlete/jaxrs/server/api/TokenEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/TokenEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Authlete, Inc.
+ * Copyright (C) 2016-2025 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.authlete.common.api.AuthleteApiFactory;
 import com.authlete.common.util.Utils;
 import com.authlete.jaxrs.BaseTokenEndpoint;
 import com.authlete.jaxrs.TokenRequestHandler.Params;
+import com.authlete.jaxrs.spi.TokenRequestHandlerSpi;
 
 
 /**
@@ -98,8 +99,11 @@ public class TokenEndpoint extends BaseTokenEndpoint
         // Parameters for Authlete's /api/auth/token API.
         Params params = buildParams(request, parameters);
 
+        // The implementation of the SPI.
+        TokenRequestHandlerSpi spi = new TokenRequestHandlerSpiImpl(authleteApi, request);
+
         // Handle the token request.
-        return handle(authleteApi, new TokenRequestHandlerSpiImpl(authleteApi), params);
+        return handle(authleteApi, spi, params);
     }
 
 

--- a/src/main/java/com/authlete/jaxrs/server/core/SessionTracker.java
+++ b/src/main/java/com/authlete/jaxrs/server/core/SessionTracker.java
@@ -1,0 +1,112 @@
+package com.authlete.jaxrs.server.core;
+
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Session Tracker to track active session IDs.
+ *
+ * <p>
+ * This class is designed to check whether a session corresponding to a given
+ * session ID exists.
+ * </p>
+ *
+ * <p>
+ * To support the "<a href=
+ * "https://openid.net/specs/openid-connect-native-sso-1_0.html">OpenID Connect
+ * Native SSO for Mobile Apps 1.0</a>" specification (a.k.a. "Native SSO"), it
+ * is necessary for the token endpoint implementation to verify whether the
+ * session ID associated with a presented refresh token or subject token
+ * exists. For this purpose, the {@link #isActiveSessionId(String)} method is
+ * used.
+ * </p>
+ *
+ * <p>
+ * When a token request compliant with Native SSO is processed by Authlete's
+ * {@code /auth/token} API, the {@code action} field in the API response will
+ * be {@link com.authlete.common.dto.TokenResponse.Action#NATIVE_SSO NATIVE_SSO},
+ * and the session ID corresponding to the refresh token or subject token will
+ * be included as the value of the {@code sessionId} parameter. This value
+ * should be passed to the {@link #isActiveSessionId(String)} method to
+ * determine whether the session ID is still active.
+ * </p>
+ *
+ * <p>
+ * Support for the Native SSO specification was introduced in Authlete 3.0.
+ * </p>
+ *
+ * @see <a href="https://openid.net/specs/openid-connect-native-sso-1_0.html"
+ *      >OpenID Connect Native SSO for Mobile Apps 1.0</a>
+ */
+@WebListener
+public class SessionTracker implements HttpSessionListener
+{
+    private static final Set<String> activeSessionIds = new HashSet<>();
+    private static final Logger logger = LoggerFactory.getLogger(SessionTracker.class);
+
+
+    @Override
+    public void sessionCreated(HttpSessionEvent se)
+    {
+        // The session ID.
+        String sessionId = retrieveSessionId(se);
+
+        logger.debug("A session with the session ID '{}' was created.", sessionId);
+
+        // Add the session ID to the list of active session IDs.
+        activeSessionIds.add(sessionId);
+    }
+
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se)
+    {
+        // The session ID.
+        String sessionId = retrieveSessionId(se);
+
+        logger.debug("The session with the session ID '{}' was destroyed.", sessionId);
+
+        // Remove the session ID from the list of active session IDs.
+        activeSessionIds.remove(sessionId);
+    }
+
+
+    private static String retrieveSessionId(HttpSessionEvent se)
+    {
+        return se.getSession().getId();
+    }
+
+
+    /**
+     * Check whether the session corresponding to the specified session ID is
+     * active.
+     *
+     * @param sessionId
+     *         A session ID.
+     *
+     * @return
+     *         {@code true} if the session corresponding to the specified
+     *         session ID is active.
+     */
+    public static boolean isActiveSessionId(String sessionId)
+    {
+        if (sessionId == null)
+        {
+            return false;
+        }
+
+        // Whether the session with the specified session ID is active.
+        boolean active = activeSessionIds.contains(sessionId);
+
+        logger.debug("The session with the session ID '{}' is {}active.", sessionId, active ? "" : "not ");
+
+        return active;
+    }
+}

--- a/src/main/java/com/authlete/jaxrs/server/nativesso/DeviceSecret.java
+++ b/src/main/java/com/authlete/jaxrs/server/nativesso/DeviceSecret.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2025 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package com.authlete.jaxrs.server.nativesso;
+
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+
+/**
+ * Device Secret.
+ *
+ * <p>
+ * This class represents the concept of a "<a href=
+ * "https://openid.net/specs/openid-connect-native-sso-1_0.html#name-device-secret"
+ * >Device Secret</a>" introduced by the "<a href=
+ * "https://openid.net/specs/openid-connect-native-sso-1_0.html">OpenID Connect
+ * Native SSO for Mobile Apps 1.0</a>" specification ("Native SSO").
+ * </p>
+ *
+ * <p>
+ * The following is an excerpt from the specification describing the concept:
+ * </p>
+ *
+ * <blockquote>
+ * <p><i>
+ * The device secret contains relevant data to the device and the current users
+ * authenticated with the device. The device secret is completely opaque to the
+ * client and as such the AS MUST adequately protect the value such as using a
+ * JWE if the AS is not maintaining state on the backend.
+ * </i></p>
+ * </blockquote>
+ *
+ * @see <a href="https://openid.net/specs/openid-connect-native-sso-1_0.html#name-device-secret"
+ *      >OpenID Connect Native SSO for Mobile Apps 1.0, Section 3.2. Device Secret</a>
+ */
+public class DeviceSecret
+{
+    /**
+     * The value of this device secret.
+     */
+    private String value;
+
+
+    /**
+     * The value of the hash of this device secret.
+     */
+    private String hash;
+
+
+    /**
+     * The identifier of the user's authentication session associated with
+     * this device secret.
+     */
+    private String sessionId;
+
+
+    /**
+     * The identifier of the device associated with this device secret.
+     */
+    private String deviceId;
+
+
+    /**
+     * Get the value of this device secret. This corresponds to the value
+     * of the {@code device_secret} parameter in token responses.
+     *
+     * @return
+     *         The value of this device secret.
+     */
+    public String getValue()
+    {
+        return value;
+    }
+
+
+    /**
+     * Set the value of this device secret. This corresponds to the value
+     * of the {@code device_secret} parameter in token responses.
+     *
+     * @param value
+     *         The value of this device secret.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public DeviceSecret setValue(String value)
+    {
+        this.value = value;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the hash of this device secret. This corresponds to
+     * the value of the {@code ds_hash} claim in the Native SSO-compliant
+     * ID token.
+     *
+     * @return
+     *         The value of the hash of this device secret.
+     */
+    public String getHash()
+    {
+        return hash;
+    }
+
+
+    /**
+     * Set the value of the hash of this device secret. This corresponds to
+     * the value of the {@code ds_hash} claim in the Native SSO-compliant
+     * ID token.
+     *
+     * @param hash
+     *         The value of the hash of this device secret.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public DeviceSecret setHash(String hash)
+    {
+        this.hash = hash;
+
+        return this;
+    }
+
+
+    /**
+     * Get the identifier of the user's authentication session associated with
+     * this device secret. This corresponds to the {@code sid} claim in the
+     * Native SSO-compliant ID token.
+     *
+     * @return
+     *         The identifier of the user's authentication session.
+     */
+    public String getSessionId()
+    {
+        return sessionId;
+    }
+
+
+    /**
+     * Set the identifier of the user's authentication session associated with
+     * this device secret. This corresponds to the {@code sid} claim in the
+     * Native SSO-compliant ID token.
+     *
+     * @param sessionId
+     *         The identifier of the user's authentication session.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public DeviceSecret setSessionId(String sessionId)
+    {
+        this.sessionId = sessionId;
+
+        return this;
+    }
+
+
+    /**
+     * Get the identifier of the device associated with this device secret.
+     *
+     * @return
+     *         The identifier of the device.
+     */
+    public String getDeviceId()
+    {
+        return deviceId;
+    }
+
+
+    /**
+     * Set the identifier of the device associated with this device secret.
+     *
+     * @param deviceId
+     *         The identifier of the device.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public DeviceSecret setDeviceId(String deviceId)
+    {
+        this.deviceId = deviceId;
+
+        return this;
+    }
+
+
+    /**
+     * Compute the hash of the specified device secret value.
+     *
+     * @param deviceSecretValue
+     *         A device secret value.
+     *
+     * @return
+     *         The hash of the specified device secret value.
+     */
+    public static String computeHash(String deviceSecretValue)
+    {
+        if (deviceSecretValue == null)
+        {
+            return null;
+        }
+
+        // The Native SSO specification does not define any logic for computing
+        // the hash from a device secret. It explicitly states as follows:
+        //
+        //   The exact binding between the ds_hash and device_secret is not
+        //   specified by this profile. As this binding is managed solely by
+        //   the Authorization Server, the AS can choose how to protect the
+        //   relationship between the id_token and device_secret.
+        //
+
+        // The following logic is specific to this implementation.
+
+        // BASE64URL( SHA-256( deviceSecretValue ) )
+        return toBase64Url(sha256(deviceSecretValue));
+    }
+
+
+    /**
+     * Convert the input data into a base64url string without padding.
+     */
+    private static String toBase64Url(byte[] input)
+    {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(input);
+    }
+
+
+    /**
+     * Compute the digest of the input data with the specified hash algorithm.
+     */
+    private static byte[] digest(String algorithm, byte[] input) throws NoSuchAlgorithmException
+    {
+        return MessageDigest.getInstance(algorithm).digest(input);
+    }
+
+
+    /**
+     * Compute the digest of the input data with the SHA-256 algorithm.
+     */
+    private static byte[] sha256(byte[] input)
+    {
+        try
+        {
+            return digest("SHA-256", input);
+        }
+        catch (NoSuchAlgorithmException cause)
+        {
+            // This error will never happen because every Java platform
+            // must support "SHA-256".
+            throw new UnsupportedOperationException(
+                    "This Java platform does not support 'SHA-256' for message digest: "
+                    + cause.getMessage(), cause);
+        }
+    }
+
+
+    /**
+     * Compute the digest of the input data with the SHA-256 algorithm.
+     */
+    private static byte[] sha256(String input)
+    {
+        return sha256(input.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/authlete/jaxrs/server/nativesso/DeviceSecretManager.java
+++ b/src/main/java/com/authlete/jaxrs/server/nativesso/DeviceSecretManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package com.authlete.jaxrs.server.nativesso;
+
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class DeviceSecretManager
+{
+    private static final Map<String, DeviceSecret> byValueMap = new ConcurrentHashMap<>();
+
+
+    private DeviceSecretManager()
+    {
+    }
+
+
+    public static DeviceSecret getByValue(String deviceSecret)
+    {
+        if (deviceSecret == null)
+        {
+            return null;
+        }
+
+        return byValueMap.get(deviceSecret);
+    }
+
+
+    public static void register(DeviceSecret ds)
+    {
+        if (ds == null)
+        {
+            return;
+        }
+
+        if (ds.getValue() == null)
+        {
+            throw new IllegalArgumentException("The value of the specified DeviceSecret is null.");
+        }
+
+        byValueMap.put(ds.getValue(), ds);
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -12,6 +12,10 @@
     <listener-class>com.authlete.jaxrs.server.core.AppContextListener</listener-class>
   </listener>
 
+  <listener>
+    <listener-class>com.authlete.jaxrs.server.core.SessionTracker</listener-class>
+  </listener>
+
   <filter>
     <filter-name>API</filter-name>
 


### PR DESCRIPTION
- Authorization Decision Endpoint
  - Support the `getSessionId()` method of the `AuthorizationDecisionHandlerSpi` interface, introduced in version 2.86 of authlete-java-jaxrs.

- Token Endpoint
  - Reflect the method signature change of the `tokenExchange(TokenResponse)` method in the `TokenRequestHandlerSpi` interface. The new signature is `tokenExchange(TokenResponse, Map<String, Object>)`, as updated in version 2.86 of authlete-java-jaxrs.
  - Reflect the method signature change of the `jwtBearer(TokenResponse)` method in the `TokenRequestHandlerSpi` interface. The new signature is `jwtBearer(TokenResponse, Map<String, Object>)`, as updated in version 2.86 of authlete-java-jaxrs.
  - Implement the `nativeSso(TokenResponse, Map<String, Object>)` method in the `TokenRequestHandlerSpi` interface, introduced in version 2.86 of authlete-java-jaxrs.

- Native SSO
  - Add the `NativeSsoProcessor` class, which is an implementation of the `nativeSso(TokenResponse, Map<String, Object>)` method in the `TokenRequestHandlerSpi` interface.
  - Add the `SessionTracker` class, which tracks active sessions.
  - Add the `DeviceSecret` class, representing the concept of a "Device Secret" as introduced in the "OpenID Connect Native SSO for Mobile Apps 1.0" specification ("Native SSO").
  - Add the `DeviceSecretManager` class, which manages `DeviceSecret` instances.

- `pom.xml`
  - Update the version of authlete-java-common from 4.12 to 4.19.
  - Update the version of authlete-java-jaxrs from 2.80 to 2.86.

- `web.xml`
  - Add `com.authlete.jaxrs.server.core.SessionTracker` as a listener class.