### PR TITLE
Fix logback version mismatch preventing Jetty startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,13 +133,13 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.15</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.32</version>
+      <version>1.7.36</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- Update logback-classic from 1.2.13 to 1.3.15 to match logback-core version
  - Update slf4j-api from 1.7.32 to 1.7.36 for better compatibility
  - Resolves NoClassDefFoundError: