### PR TITLE
Upgrade vulnerable dependencies and fix postal code method typo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <authlete.java.common.version>4.19</authlete.java.common.version>
+    <authlete.java.common.version>4.21</authlete.java.common.version>
     <authlete.java.jaxrs.version>2.86</authlete.java.jaxrs.version>
     <authlete.cbor.version>1.18</authlete.cbor.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-    <jersey.version>2.30.1</jersey.version>
+    <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.27.v20200227</jetty.version>
     <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
@@ -114,14 +114,13 @@
     <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
-        <version>1.78</version>
+        <version>1.78.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>oauth2-oidc-sdk</artifactId>
-      <classifier>jdk8</classifier>
-      <version>9.22</version>
+      <version>9.43.4</version>
     </dependency>
 
     <dependency>
@@ -133,7 +132,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.15</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserDao.java
@@ -70,7 +70,7 @@ public class UserDao
                         .setCountry("USA")
                         .setLocality("Shoshone")
                         .setStreetAddress("114 Old State Hwy 127")
-                        .setPostaCode("CA 92384"),
+                        .setPostalCode("CA 92384"),
                     null, null, "Inga", "Silverstone", null, null,
                     "https://example.com/inga/profile", "https://example.com/inga/me.jpg",
                     "https://example.com/inga/", "female", "America/Toronto", "en-US",

--- a/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
+++ b/src/main/java/com/authlete/jaxrs/server/db/UserEntity.java
@@ -210,7 +210,7 @@ public class UserEntity implements User, Serializable
                 .setCountry(addr.getCountry())
                 .setFormatted(addr.getFormatted())
                 .setLocality(addr.getLocality())
-                .setPostaCode(addr.getPostalCode())
+                .setPostalCode(addr.getPostalCode())
                 .setRegion(addr.getRegion())
                 .setStreetAddress(addr.getStreetAddress())
                 ;


### PR DESCRIPTION
## Description:
Updated project dependencies to address security vulnerabilities and improve compatibility. Also fixed a typo in postal code setter methods.

### Changes:
- Updated `authlete.java.common` from `4.19` to `4.21`
- Updated `jersey` from `2.30.1` to `2.34`
- Updated `bcpkix-jdk18on` from `1.78` to `1.78.1`
- Updated `oauth2-oidc-sdk` from `9.22` (jdk8 classifier) to `9.43.4`
- Updated `logback-classic` from `1.2.13` to `1.3.15`
- Fixed method name typo: `.setPostaCode()` → `.setPostalCode()` in `UserDao` and `UserEntity`
