### PR TITLE
Remove charset=utf-8 from json contentype type

### DIFF
--- a/src/main/java/com/authlete/jaxrs/server/util/ResponseUtil.java
+++ b/src/main/java/com/authlete/jaxrs/server/util/ResponseUtil.java
@@ -47,10 +47,10 @@ public class ResponseUtil
             MediaType.TEXT_PLAIN_TYPE.withCharset("UTF-8");
 
     /**
-     * {@code "application/json;charset=UTF-8"}
+     * {@code "application/json"}
      */
     private static final MediaType MEDIA_TYPE_JSON =
-            MediaType.APPLICATION_JSON_TYPE.withCharset("UTF-8");
+            MediaType.APPLICATION_JSON_TYPE;
 
     /**
      * {@code "application/jwt"}


### PR DESCRIPTION
It's not needed as json is utf8 by default and the charset tag has no defined meaning for this content type.