### PR TITLE
fix: accept application/jwt on VCI credential endpoints

### DIFF
--- a/src/main/java/com/authlete/jaxrs/server/api/vci/BatchCredentialEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/vci/BatchCredentialEndpoint.java
@@ -46,7 +46,7 @@ import com.authlete.jaxrs.server.util.ResponseUtil;
 public class BatchCredentialEndpoint extends AbstractCredentialEndpoint
 {
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes({ MediaType.APPLICATION_JSON, "application/jwt" })
     public Response post(
             @Context HttpServletRequest request,
             @HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,

--- a/src/main/java/com/authlete/jaxrs/server/api/vci/CredentialEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/vci/CredentialEndpoint.java
@@ -47,7 +47,7 @@ import com.authlete.jaxrs.server.vc.OrderContext;
 public class CredentialEndpoint extends AbstractCredentialEndpoint
 {
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes({ MediaType.APPLICATION_JSON, "application/jwt" })
     public Response post(
             @Context HttpServletRequest request,
             @HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,

--- a/src/main/java/com/authlete/jaxrs/server/api/vci/DeferredCredentialEndpoint.java
+++ b/src/main/java/com/authlete/jaxrs/server/api/vci/DeferredCredentialEndpoint.java
@@ -47,7 +47,7 @@ import com.authlete.jaxrs.server.vc.OrderContext;
 public class DeferredCredentialEndpoint extends AbstractCredentialEndpoint
 {
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes({ MediaType.APPLICATION_JSON, "application/jwt" })
     public Response post(
             @Context HttpServletRequest request,
             @HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,


### PR DESCRIPTION
OID4VCI encrypted credential requests are sent as a JWE with Content-Type: application/jwt, but the endpoints only advertised application/json, so JAX-RS rejected them with 415 before the handler ran. Accept both media types; the Authlete parse APIs already handle JWE decryption downstream.